### PR TITLE
Direct readers to the original, since it now supports Babel 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # babel-plugin-dynamic-import-node
 
+## NOTE: THE ORIGINAL NOW SUPPORTS BABEL 7
+
+As of March 2019, [airbnb/babel-plugin-dynamic-import-node](https://github.com/airbnb/babel-plugin-dynamic-import-node) supports Babel 7 out-of-the-box, so you probably don't need to use this.
+
 ## FORK OF THE ORIGINAL TO TEST WITH BABEL 7
 
 If you're looking for the original one, check on: [Github](https://github.com/airbnb/babel-plugin-dynamic-import-node)


### PR DESCRIPTION
I was confused for a while because I found a link to this repository somewhere and from its name and readme, assumed that the original repo didn't support Babel 7.  I then ran into some errors because default exports aren't exported properly by this repo.  It was only after some experimentation that I discovered that the original now supports Babel 7, and switched to that.

This PR just mentions that the original now supports Babel 7.  It might also be a good idea to [archive this repository](https://help.github.com/en/articles/archiving-repositories) so folks know that it's no longer maintained?